### PR TITLE
Added ScrollToTop component for smooth scroll on route change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AnimatePresence } from 'framer-motion';
 import Header from './components/Header';
 import Footer from './components/Footer';
@@ -8,12 +8,31 @@ import About from './pages/About';
 import './App.css';
 import Features from './components/Features';
 import Community from './pages/Community';
+import { useEffect } from 'react';
+
+  // when i change the url, i want to scroll to the top smoothly
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  }, [pathname]);
+
+  return null;
+}
 
 function App() {
+
   return (
     <Router>
       <div className="App">
         <Header />
+       {/* ScrollToTop will handle smooth scrolling on route change */}
+        <ScrollToTop />
+        
         <AnimatePresence mode="wait">
           <Routes>
             <Route path="/" element={<Home />} />


### PR DESCRIPTION
“Ensure that when a user navigates to a new route, the page automatically scrolls to the top. Currently, if the user is at the bottom or middle of a page and navigates to another page (e.g., the Community page), the scroll position remains unchanged. The scroll should reset to the top of the new page regardless of the user’s previous scroll position.”
i fixed it check it and review 